### PR TITLE
fix: call apt-update before installing linux dependencies

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -99,6 +99,7 @@ jobs:
           path: build-static/
           key: swig-win-3-${{ env.swig_hash }}
       - run: |
+          sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends autoconf automake bison build-essential mingw-w64
         if: steps.swig-build-cache.outputs.cache-hit != 'true'
       - run: |
@@ -334,7 +335,7 @@ jobs:
           submodules: 'recursive'
       - name: Install dependencies
         run: |
-          apt-get update
+          apt-get update -y
           apt-get install -y --no-install-recommends xz-utils zip liblzma-dev libbz2-dev
       - name: Setup venv
         run: |
@@ -376,7 +377,7 @@ jobs:
           path: ${{ github.workspace }}/tensorflow/bazel-bin/native_client/
       - name: Install dependencies
         run: |
-          apt-get update
+          apt-get update -y
           apt-get install -y --no-install-recommends xz-utils liblzma-dev libbz2-dev
       - name: Extract native_client.tar.xz
         run: |
@@ -473,7 +474,7 @@ jobs:
           node-version: 16
       - name: Install dependencies
         run: |
-          apt-get update
+          apt-get update -y
           apt-get install -y --no-install-recommends xz-utils zip liblzma-dev libbz2-dev
       - name: Setup venv
         run: |
@@ -572,6 +573,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: |
+          sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends sox
       - uses: actions/download-artifact@v3
         with:
@@ -630,6 +632,7 @@ jobs:
       - run: |
           python -m pip install coqui_stt_ctcdecoder-*.whl
       - run: |
+          sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends libopus0 libopusfile0
       - run: |
           ./ci_scripts/evaluate-export-test.sh ${{ matrix.samplerate }}
@@ -656,6 +659,7 @@ jobs:
         with:
           node-version: ${{ matrix.nodejs-version }}
       - run: |
+          sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends sox
       - uses: actions/download-artifact@v3
         with:
@@ -707,6 +711,7 @@ jobs:
         with:
           node-version: 12
       - run: |
+          sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends sox
       - uses: actions/download-artifact@v3
         with:
@@ -753,6 +758,7 @@ jobs:
         with:
           name: "coqui_stt_ctcdecoder-Linux-3.7.whl"
       - run: |
+          sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends libopusfile0 libopus-dev libopusfile-dev
       - run: |
           python --version
@@ -857,6 +863,7 @@ jobs:
       - run: |
           mkdir -p ${CI_ARTIFACTS_DIR} || true
       - run: |
+          sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends libopus0 libopusfile0 libvorbis-dev sox
       - name: Run tests
         run: |
@@ -911,6 +918,7 @@ jobs:
       - run: |
           mkdir -p ${CI_ARTIFACTS_DIR} || true
       - run: |
+          sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends libopus0 sox
       - name: Run tests
         run: |
@@ -955,6 +963,7 @@ jobs:
       - run: |
           mkdir -p ${CI_ARTIFACTS_DIR} || true
       - run: |
+          sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends libopus0 sox
       - name: Run tests
         run: |
@@ -995,6 +1004,7 @@ jobs:
       - run: |
           mkdir -p ${CI_ARTIFACTS_DIR} || true
       - run: |
+          sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends libopus0 sox
       - name: Run tests
         run: |
@@ -1040,6 +1050,7 @@ jobs:
       - run: |
           mkdir -p ${CI_ARTIFACTS_DIR} || true
       - run: |
+          sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends libopus0 sox
       - name: Run tests
         run: |
@@ -1391,6 +1402,7 @@ jobs:
         with:
           python-version: 3.7
       - run: |
+          sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends libopusfile0 libopus-dev libopusfile-dev
       - run: |
           python -m pip install -U pip setuptools wheel jupyter
@@ -2527,6 +2539,7 @@ jobs:
         with:
           node-version: ${{ matrix.nodejs-version }}
       - run: |
+          sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends sox
       - uses: actions/download-artifact@v3
         with:
@@ -2578,6 +2591,7 @@ jobs:
         with:
           node-version: 12
       - run: |
+          sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends sox
       - uses: actions/download-artifact@v3
         with:
@@ -3052,6 +3066,7 @@ jobs:
       SYSTEM_RASPBIAN: ${{ github.workspace }}/${{ matrix.system-raspbian }}
     steps:
       - run: |
+          sudo apt-get update -y
           sudo apt-get install -y --no-install-recommends
       - uses: actions/checkout@v3
         with:

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 .. note::
    **This project is no longer actively maintained**, and we have stopped hosting the online Model Zoo. We've seen focus shift towards newer STT models such as [Whisper](https://github.com/openai/whisper), and have ourselves focused on [Coqui TTS](https://github.com/coqui-ai/TTS) and [Coqui Studio](https://coqui.ai/).
-   
+
    The models will remain available in [the releases of the coqui-ai/STT-models repo](https://github.com/coqui-ai/STT-models/releases).
 
 .. image:: images/coqui-STT-logo-green.png


### PR DESCRIPTION
This PR fixes https://github.com/iarahealth/STT/issues/12, by calling apt-get update before installing linux dependencies on linux runners. This solution was suggested in this gh actions https://github.com/actions/runner-images/issues/675#.