### PR TITLE
feat: enable ARM builds for macOS

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1443,7 +1443,16 @@ jobs:
   # macOS jobs
   swig_macOS:
     name: "Mac|Build SWIG"
-    runs-on: macos-12
+    strategy:
+      matrix:
+        include:
+          - os: self-hosted
+            arch: arm64
+            artifact_suffix: arm64
+          - os: macos-12
+            arch: x86_64
+            artifact_suffix: x64
+    runs-on: ${{ matrix.os }}
     env:
       swig_hash: "90cdbee6a69d13b39d734083b9f91069533b0d7b"
     steps:
@@ -1457,7 +1466,7 @@ jobs:
         id: swig-build-cache
         with:
           path: build-static/
-          key: swig-${{ runner.os }}-${{ env.swig_hash }}
+          key: swig-${{ runner.os }}-${{ matrix.arch }}-${{ env.swig_hash }}
       - run: |
           brew install automake
         if: steps.swig-build-cache.outputs.cache-hit != 'true'
@@ -1481,7 +1490,7 @@ jobs:
         if: steps.swig-build-cache.outputs.cache-hit != 'true'
       - uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.job }}
+          name: ${{ github.job }}.${{ matrix.artifact_suffix }}
           path: ${{ github.workspace }}/build-static/
   build-ctc-decoder-macos:
     name: "Mac|Build CTC decoder Python package"
@@ -1502,7 +1511,7 @@ jobs:
           pip --version
       - uses: actions/download-artifact@v3
         with:
-          name: "swig_macOS"
+          name: "swig_macOS.x64"
           path: ${{ github.workspace }}/native_client/ds-swig/
       - name: Link ds-swig into swig
         run: |
@@ -1769,7 +1778,7 @@ jobs:
           tar xf native_client.tar.xz
       - uses: actions/download-artifact@v3
         with:
-          name: "swig_macOS"
+          name: "swig_macOS.x64"
           path: ${{ github.workspace }}/native_client/ds-swig/
       - name: Link ds-swig into swig
         run: |
@@ -1797,8 +1806,17 @@ jobs:
           path: ${{ github.workspace }}/native_client/python/dist/*.whl
   build-nodejs-macOS:
     name: "Mac|Build NodeJS and ElectronJS"
-    runs-on: macos-12
+    runs-on: ${{ matrix.os }}
     needs: [build-universal-lib-macOS, swig_macOS]
+    strategy:
+      matrix:
+        include:
+          - os: self-hosted
+            arch: arm64
+            nodejs-version: 18
+          - os: macos-12
+            arch: x64
+            nodejs-version: 12
     steps:
       - uses: actions/checkout@v3
         with:
@@ -1812,7 +1830,7 @@ jobs:
           tar xf native_client.tar.xz
       - uses: actions/download-artifact@v3
         with:
-          name: "swig_macOS"
+          name: "swig_macOS.${{ matrix.arch }}"
           path: ${{ github.workspace }}/native_client/ds-swig/
       - name: Link ds-swig into swig
         run: |
@@ -1821,7 +1839,8 @@ jobs:
           chmod +x ${{ github.workspace }}/native_client/ds-swig/bin/ds-swig ${{ github.workspace }}/native_client/ds-swig/bin/swig
       - uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: ${{ matrix.nodejs-version }}
+          architecture: ${{ matrix.arch }}
       - uses: actions/cache@v3
         id: node-headers-cache
         with:
@@ -1838,11 +1857,11 @@ jobs:
           electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0"
       - uses: actions/upload-artifact@v3
         with:
-          name: "nodewrapper-tflite-macOS_amd64.tar.gz"
+          name: "nodewrapper-tflite-macOS_${{ matrix.arch }}.tar.gz"
           path: ${{ github.workspace }}/native_client/javascript/wrapper.tar.gz
       - uses: actions/upload-artifact@v3
         with:
-          name: "stt_intermediate-tflite-macOS.tgz"
+          name: "stt_intermediate-tflite-macOS_${{ matrix.arch }}.tgz"
           path: ${{ github.workspace }}/native_client/javascript/stt-*.tgz
   test-cpp-macOS:
     name: "Mac|Test C++ binary"
@@ -1944,7 +1963,7 @@ jobs:
           node-version: ${{ matrix.nodejs-version }}
       - uses: actions/download-artifact@v3
         with:
-          name: "stt_intermediate-tflite-macOS.tgz"
+          name: "stt_intermediate-tflite-macOS_x64.tgz"
           path: ${{ env.CI_TMP_DIR }}
       - uses: actions/download-artifact@v3
         with:
@@ -2469,12 +2488,17 @@ jobs:
         with:
           fetch-depth: 1
       - run: |
-          mkdir -p /tmp/nodewrapper-tflite-macOS_amd64/
+          mkdir -p /tmp/nodewrapper-tflite-macOS_x64/
+          mkdir -p /tmp/nodewrapper-tflite-macOS_arm64/
           mkdir -p /tmp/nodewrapper-tflite-Windows_amd64/
       - uses: actions/download-artifact@v3
         with:
-          name: "nodewrapper-tflite-macOS_amd64.tar.gz"
-          path: /tmp/nodewrapper-macOS_amd64/
+          name: "nodewrapper-tflite-macOS_x64.tar.gz"
+          path: /tmp/nodewrapper-macOS_x64/
+      - uses: actions/download-artifact@v3
+        with:
+          name: "nodewrapper-tflite-macOS_arm64.tar.gz"
+          path: /tmp/nodewrapper-macOS_arm64/
       - uses: actions/download-artifact@v3
         with:
           name: "nodewrapper-tflite-Windows_amd64.tar.gz"
@@ -2493,7 +2517,8 @@ jobs:
           path: /tmp/nodewrapper-Linux_aarch64/
       - name: Extract nodewrapper archives
         run: |
-          tar -C ${{ github.workspace }}/native_client/javascript -xzvf /tmp/nodewrapper-macOS_amd64/wrapper.tar.gz
+          tar -C ${{ github.workspace }}/native_client/javascript -xzvf /tmp/nodewrapper-macOS_arm64/wrapper.tar.gz
+          tar -C ${{ github.workspace }}/native_client/javascript -xzvf /tmp/nodewrapper-macOS_x64/wrapper.tar.gz
           tar -C ${{ github.workspace }}/native_client/javascript -xzvf /tmp/nodewrapper-Windows_amd64/wrapper.tar.gz
           tar -C ${{ github.workspace }}/native_client/javascript -xzvf /tmp/nodewrapper-Linux_amd64/wrapper.tar.gz
           tar -C ${{ github.workspace }}/native_client/javascript -xzvf /tmp/nodewrapper-Linux_armv7/wrapper.tar.gz
@@ -2610,7 +2635,7 @@ jobs:
         timeout-minutes: 5
   test-nodejs_all-macOS:
     name: "Mac|Test MultiArchPlatform NodeJS bindings"
-    runs-on: macos-12
+    runs-on: ${{ matrix.os }}
     needs: [repackage-nodejs-allplatforms, train-test-model-Linux]
     if: ${{ github.event_name == 'pull_request' }}
     strategy:
@@ -2619,6 +2644,11 @@ jobs:
         nodejs-version: [12, 17]
         models: ["test", "prod"]
         samplerate: ["8000", "16000"]
+        include:
+          - os: self-hosted
+            arch: arm64
+          - os: macos-12
+            arch: x86_64
       fail-fast: false
     env:
       CI_TMP_DIR: ${{ github.workspace }}/tmp/

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2011,7 +2011,7 @@ jobs:
           node-version: 12
       - uses: actions/download-artifact@v3
         with:
-          name: "stt_intermediate-tflite-macOS.tgz"
+          name: "stt_intermediate-tflite-macOS_x64.tgz"
           path: ${{ env.CI_TMP_DIR }}
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1804,7 +1804,11 @@ jobs:
     needs: [build-universal-lib-macOS, swig_macOS]
     strategy:
       matrix:
-        arch: [arm64, x86_64]
+        include:
+          - arch: x86_64
+            node-arch: x64
+          - arch: arm64
+            node-arch: arm64
     steps:
       - uses: actions/checkout@v3
         with:
@@ -1828,7 +1832,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-          architecture: ${{ matrix.arch }}
+          architecture: ${{ matrix.node-arch }}
       - uses: actions/cache@v3
         id: node-headers-cache
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1445,14 +1445,8 @@ jobs:
     name: "Mac|Build SWIG"
     strategy:
       matrix:
-        include:
-          - os: self-hosted
-            arch: arm64
-            artifact_suffix: arm64
-          - os: macos-12
-            arch: x86_64
-            artifact_suffix: x64
-    runs-on: ${{ matrix.os }}
+        arch: [arm64, x86_64]
+    runs-on: macos-12
     env:
       swig_hash: "90cdbee6a69d13b39d734083b9f91069533b0d7b"
     steps:
@@ -1490,7 +1484,7 @@ jobs:
         if: steps.swig-build-cache.outputs.cache-hit != 'true'
       - uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.job }}.${{ matrix.artifact_suffix }}
+          name: ${{ github.job }}.${{ matrix.arch }}
           path: ${{ github.workspace }}/build-static/
   build-ctc-decoder-macos:
     name: "Mac|Build CTC decoder Python package"
@@ -1511,7 +1505,7 @@ jobs:
           pip --version
       - uses: actions/download-artifact@v3
         with:
-          name: "swig_macOS.x64"
+          name: "swig_macOS.x86_64"
           path: ${{ github.workspace }}/native_client/ds-swig/
       - name: Link ds-swig into swig
         run: |
@@ -1778,7 +1772,7 @@ jobs:
           tar xf native_client.tar.xz
       - uses: actions/download-artifact@v3
         with:
-          name: "swig_macOS.x64"
+          name: "swig_macOS.x86_64"
           path: ${{ github.workspace }}/native_client/ds-swig/
       - name: Link ds-swig into swig
         run: |
@@ -1806,17 +1800,11 @@ jobs:
           path: ${{ github.workspace }}/native_client/python/dist/*.whl
   build-nodejs-macOS:
     name: "Mac|Build NodeJS and ElectronJS"
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-12
     needs: [build-universal-lib-macOS, swig_macOS]
     strategy:
       matrix:
-        include:
-          - os: self-hosted
-            arch: arm64
-            nodejs-version: 18
-          - os: macos-12
-            arch: x64
-            nodejs-version: 12
+        arch: [arm64, x86_64]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -1839,7 +1827,7 @@ jobs:
           chmod +x ${{ github.workspace }}/native_client/ds-swig/bin/ds-swig ${{ github.workspace }}/native_client/ds-swig/bin/swig
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.nodejs-version }}
+          node-version: 18
           architecture: ${{ matrix.arch }}
       - uses: actions/cache@v3
         id: node-headers-cache
@@ -1963,7 +1951,7 @@ jobs:
           node-version: ${{ matrix.nodejs-version }}
       - uses: actions/download-artifact@v3
         with:
-          name: "stt_intermediate-tflite-macOS_x64.tgz"
+          name: "stt_intermediate-tflite-macOS_x86_64.tgz"
           path: ${{ env.CI_TMP_DIR }}
       - uses: actions/download-artifact@v3
         with:
@@ -2011,7 +1999,7 @@ jobs:
           node-version: 12
       - uses: actions/download-artifact@v3
         with:
-          name: "stt_intermediate-tflite-macOS_x64.tgz"
+          name: "stt_intermediate-tflite-macOS_x86_64.tgz"
           path: ${{ env.CI_TMP_DIR }}
       - uses: actions/download-artifact@v3
         with:
@@ -2488,13 +2476,13 @@ jobs:
         with:
           fetch-depth: 1
       - run: |
-          mkdir -p /tmp/nodewrapper-tflite-macOS_x64/
+          mkdir -p /tmp/nodewrapper-tflite-macOS_x86_64/
           mkdir -p /tmp/nodewrapper-tflite-macOS_arm64/
           mkdir -p /tmp/nodewrapper-tflite-Windows_amd64/
       - uses: actions/download-artifact@v3
         with:
-          name: "nodewrapper-tflite-macOS_x64.tar.gz"
-          path: /tmp/nodewrapper-macOS_x64/
+          name: "nodewrapper-tflite-macOS_x86_64.tar.gz"
+          path: /tmp/nodewrapper-macOS_x86_64/
       - uses: actions/download-artifact@v3
         with:
           name: "nodewrapper-tflite-macOS_arm64.tar.gz"
@@ -2518,7 +2506,7 @@ jobs:
       - name: Extract nodewrapper archives
         run: |
           tar -C ${{ github.workspace }}/native_client/javascript -xzvf /tmp/nodewrapper-macOS_arm64/wrapper.tar.gz
-          tar -C ${{ github.workspace }}/native_client/javascript -xzvf /tmp/nodewrapper-macOS_x64/wrapper.tar.gz
+          tar -C ${{ github.workspace }}/native_client/javascript -xzvf /tmp/nodewrapper-macOS_x86_64/wrapper.tar.gz
           tar -C ${{ github.workspace }}/native_client/javascript -xzvf /tmp/nodewrapper-Windows_amd64/wrapper.tar.gz
           tar -C ${{ github.workspace }}/native_client/javascript -xzvf /tmp/nodewrapper-Linux_amd64/wrapper.tar.gz
           tar -C ${{ github.workspace }}/native_client/javascript -xzvf /tmp/nodewrapper-Linux_armv7/wrapper.tar.gz
@@ -2635,7 +2623,7 @@ jobs:
         timeout-minutes: 5
   test-nodejs_all-macOS:
     name: "Mac|Test MultiArchPlatform NodeJS bindings"
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-12
     needs: [repackage-nodejs-allplatforms, train-test-model-Linux]
     if: ${{ github.event_name == 'pull_request' }}
     strategy:
@@ -2644,11 +2632,7 @@ jobs:
         nodejs-version: [12, 17]
         models: ["test", "prod"]
         samplerate: ["8000", "16000"]
-        include:
-          - os: self-hosted
-            arch: arm64
-          - os: macos-12
-            arch: x86_64
+        arch: [arm64, x86_64]
       fail-fast: false
     env:
       CI_TMP_DIR: ${{ github.workspace }}/tmp/

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 .. note::
    **This project is no longer actively maintained**, and we have stopped hosting the online Model Zoo. We've seen focus shift towards newer STT models such as [Whisper](https://github.com/openai/whisper), and have ourselves focused on [Coqui TTS](https://github.com/coqui-ai/TTS) and [Coqui Studio](https://coqui.ai/).
-   
+
    The models will remain available in [the releases of the coqui-ai/STT-models repo](https://github.com/coqui-ai/STT-models/releases).
 
 .. image:: images/coqui-STT-logo-green.png

--- a/native_client/javascript/binding.gyp
+++ b/native_client/javascript/binding.gyp
@@ -52,6 +52,7 @@
     ],
     "variables": {
         "build_v8_with_gn": 0,
+        "openssl_fips": "",
         "v8_enable_pointer_compression": 0,
         "v8_enable_31bit_smis_on_64bit_arch": 0,
         "enable_lto": 1,


### PR DESCRIPTION
This PR enables ARM builds for the macOS nodejs bindings and the underlying libraries (other bindings still only support x64, but it should be easier to add suport for them now). 

One important consideration: Github does not yet include ARM-based macOS runners, so the build CI **needs a self-hosted runner for now**.
