### PR TITLE
feat: add electron v19 to build targets

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -447,7 +447,7 @@ jobs:
       - uses: ./.github/actions/node-build
         with:
           nodejs_versions: "12.7.0 13.0.0 14.0.0 15.0.0 16.0.0 17.0.1"
-          electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0"
+          electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0 19.0.0"
       - uses: actions/upload-artifact@v3
         with:
           name: "nodewrapper-tflite-Linux_amd64.tar.gz"
@@ -1835,7 +1835,7 @@ jobs:
       - uses: ./.github/actions/node-build
         with:
           nodejs_versions: "12.7.0 13.0.0 14.0.0 15.0.0 16.0.0 17.0.1"
-          electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0"
+          electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0 19.0.0"
       - uses: actions/upload-artifact@v3
         with:
           name: "nodewrapper-tflite-macOS_amd64.tar.gz"
@@ -2225,7 +2225,7 @@ jobs:
       - uses: ./.github/actions/win-node-build
         with:
           nodejs_versions: "12.7.0 13.0.0 14.0.0 15.0.0 16.0.0"
-          electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0"
+          electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0 19.0.0"
       - uses: actions/upload-artifact@v3
         with:
           name: "nodewrapper-tflite-Windows_amd64.tar.gz"
@@ -3021,7 +3021,7 @@ jobs:
       - uses: ./.github/actions/node-build
         with:
           nodejs_versions: "12.7.0 13.0.0 14.0.0 15.0.0 16.0.0 17.0.1"
-          electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0"
+          electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0 19.0.0"
           target: ${{ env.SYSTEM_TARGET }}
           chroot: ${{ env.SYSTEM_RASPBIAN }}
       - uses: actions/upload-artifact@v3
@@ -3160,7 +3160,7 @@ jobs:
       - uses: ./.github/actions/node-build
         with:
           nodejs_versions: "12.7.0 13.0.0 14.0.0 15.0.0 16.0.0 17.0.1"
-          electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0"
+          electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0 19.0.0"
           target: ${{ env.SYSTEM_TARGET }}
           chroot: ${{ env.SYSTEM_RASPBIAN }}
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
This PR adds Electron v19 to the list of electron build targets.
As far as I could tell, this is the latest version of Electron that can be built https://github.com/electron-userland/electron-builder/issues/7175, so I stopped there for now.
This electron versions adds some features, but most importantly will patch some vulnerabilities such as [this one](https://github.com/advisories/GHSA-p2jh-44qj-pf2v).