### PR TITLE
Replace electron v19 target with v21

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -334,6 +334,7 @@ jobs:
           submodules: 'recursive'
       - name: Install dependencies
         run: |
+          sed -i -e 's/deb.debian.org/archive.debian.org/g' -e 's|security.debian.org|archive.debian.org/|g' -e '/stretch-updates/d' /etc/apt/sources.list
           apt-get update
           apt-get install -y --no-install-recommends xz-utils zip liblzma-dev libbz2-dev
       - name: Setup venv
@@ -376,6 +377,7 @@ jobs:
           path: ${{ github.workspace }}/tensorflow/bazel-bin/native_client/
       - name: Install dependencies
         run: |
+          sed -i -e 's/deb.debian.org/archive.debian.org/g' -e 's|security.debian.org|archive.debian.org/|g' -e '/stretch-updates/d' /etc/apt/sources.list
           apt-get update
           apt-get install -y --no-install-recommends xz-utils liblzma-dev libbz2-dev
       - name: Extract native_client.tar.xz
@@ -443,11 +445,11 @@ jobs:
         id: electron-headers-cache
         with:
           path: native_client/javascript/headers/electronjs/
-          key: electron-headers-12.0.0_16.0.0
+          key: electron-headers-12.0.0_21.0.0
       - uses: ./.github/actions/node-build
         with:
           nodejs_versions: "12.7.0 13.0.0 14.0.0 15.0.0 16.0.0 17.0.1"
-          electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0 19.0.0"
+          electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0 21.0.0"
       - uses: actions/upload-artifact@v3
         with:
           name: "nodewrapper-tflite-Linux_amd64.tar.gz"
@@ -473,6 +475,7 @@ jobs:
           node-version: 16
       - name: Install dependencies
         run: |
+          sed -i -e 's/deb.debian.org/archive.debian.org/g' -e 's|security.debian.org|archive.debian.org/|g' -e '/stretch-updates/d' /etc/apt/sources.list
           apt-get update
           apt-get install -y --no-install-recommends xz-utils zip liblzma-dev libbz2-dev
       - name: Setup venv
@@ -1831,11 +1834,11 @@ jobs:
         id: electron-headers-cache
         with:
           path: native_client/javascript/headers/electronjs/
-          key: electron-headers-12.0.0_16.0.0
+          key: electron-headers-12.0.0_21.0.0
       - uses: ./.github/actions/node-build
         with:
           nodejs_versions: "12.7.0 13.0.0 14.0.0 15.0.0 16.0.0 17.0.1"
-          electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0 19.0.0"
+          electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0 21.0.0"
       - uses: actions/upload-artifact@v3
         with:
           name: "nodewrapper-tflite-macOS_amd64.tar.gz"
@@ -2225,7 +2228,7 @@ jobs:
       - uses: ./.github/actions/win-node-build
         with:
           nodejs_versions: "12.7.0 13.0.0 14.0.0 15.0.0 16.0.0"
-          electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0 19.0.0"
+          electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0 21.0.0"
       - uses: actions/upload-artifact@v3
         with:
           name: "nodewrapper-tflite-Windows_amd64.tar.gz"
@@ -3010,7 +3013,7 @@ jobs:
         id: electron-headers-cache
         with:
           path: native_client/javascript/headers/electronjs/
-          key: electron-headers-12.0.0_16.0.0
+          key: electron-headers-12.0.0_21.0.0
       - name: Download cross-build toolchain
         run: |
           cd tensorflow
@@ -3021,7 +3024,7 @@ jobs:
       - uses: ./.github/actions/node-build
         with:
           nodejs_versions: "12.7.0 13.0.0 14.0.0 15.0.0 16.0.0 17.0.1"
-          electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0 19.0.0"
+          electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0 21.0.0"
           target: ${{ env.SYSTEM_TARGET }}
           chroot: ${{ env.SYSTEM_RASPBIAN }}
       - uses: actions/upload-artifact@v3
@@ -3149,7 +3152,7 @@ jobs:
         id: electron-headers-cache
         with:
           path: native_client/javascript/headers/electronjs/
-          key: electron-headers-12.0.0_16.0.0
+          key: electron-headers-12.0.0_21.0.0
       - name: Download cross-build toolchain
         run: |
           cd tensorflow
@@ -3160,7 +3163,7 @@ jobs:
       - uses: ./.github/actions/node-build
         with:
           nodejs_versions: "12.7.0 13.0.0 14.0.0 15.0.0 16.0.0 17.0.1"
-          electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0 19.0.0"
+          electronjs_versions: "12.0.0 13.0.0 14.0.0 15.0.0 16.0.0 21.0.0"
           target: ${{ env.SYSTEM_TARGET }}
           chroot: ${{ env.SYSTEM_RASPBIAN }}
       - uses: actions/upload-artifact@v3

--- a/native_client/definitions.mk
+++ b/native_client/definitions.mk
@@ -148,8 +148,8 @@ LDFLAGS_NEEDED := -Wl,--no-as-needed
 LDFLAGS_RPATH  := -Wl,-rpath,\$$ORIGIN
 endif
 ifeq ($(OS),Darwin)
-CXXFLAGS       += -stdlib=libc++
-LDFLAGS_NEEDED := -stdlib=libc++
+CXXFLAGS       += -stdlib=libc++ -std=c++17
+LDFLAGS_NEEDED := -stdlib=libc++ -std=c++17
 LDFLAGS_RPATH  := -Wl,-rpath,@executable_path
 endif
 

--- a/native_client/javascript/binding.gyp
+++ b/native_client/javascript/binding.gyp
@@ -5,11 +5,14 @@
             "sources": ["stt_wrap.cxx"],
             "libraries": [],
             "include_dirs": ["../"],
+            "cflags_cc": ["-std=c++17"],
             "conditions": [
                 [
                     "OS=='mac'",
                     {
                         "xcode_settings": {
+                            "CLANG_CXX_LIBRARY": "libc++",
+                            "CLANG_CXX_LANGUAGE_STANDARD": "c++17",
                             "OTHER_CXXFLAGS": [
                                 "-stdlib=libc++",
                                 "-mmacosx-version-min=10.10",
@@ -24,6 +27,9 @@
                 [
                     "OS=='win'",
                     {
+                        "msvs_settings": {
+                            "VCCLCompilerTool": {"AdditionalOptions": ["/std:c++17"]}
+                        },
                         "libraries": [
                             "../../../tensorflow/bazel-bin/native_client/libstt.so.if.lib",
                             "../../../tensorflow/bazel-bin/native_client/libkenlm.so.if.lib",
@@ -52,6 +58,7 @@
     ],
     "variables": {
         "build_v8_with_gn": 0,
+        "openssl_fips": "",
         "v8_enable_pointer_compression": 0,
         "v8_enable_31bit_smis_on_64bit_arch": 0,
         "enable_lto": 1,

--- a/native_client/javascript/package.json.in
+++ b/native_client/javascript/package.json.in
@@ -40,7 +40,7 @@
     },
     "devDependencies": {
       "electron": "^1.7.9",
-      "node-gyp": "5.x",
+      "node-gyp": "9.x",
       "typescript": "3.8.x",
       "typedoc": "0.17.x",
       "@types/argparse": "1.0.x",


### PR DESCRIPTION
This PR replaces electron v19 target with v21, which brings several improvements in performance, stability and security, specially the [v8 memory cage](https://www.electronjs.org/blog/v8-memory-cage), which may reduce electron crashes.