### PR TITLE
feat: allow unicode (en_US) model paths

### DIFF
--- a/native_client/javascript/package.json.in
+++ b/native_client/javascript/package.json.in
@@ -40,7 +40,7 @@
     },
     "devDependencies": {
       "electron": "^1.7.9",
-      "node-gyp": "9.x",
+      "node-gyp": "9.3.x",
       "typescript": "3.8.x",
       "typedoc": "0.17.x",
       "@types/argparse": "1.0.x",

--- a/native_client/stt.cc
+++ b/native_client/stt.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <locale>
 
 #include "coqui-stt.h"
 #include "alphabet.h"
@@ -340,6 +341,7 @@ CreateModelImpl(const char* aModelString,
                 unsigned int aBufferSize = 0)
 {
   *retval = nullptr;
+  setlocale(LC_ALL, "en_US.UTF-8");
 
   std::cerr << "TensorFlow: " << tf_local_git_version() << std::endl;
   std::cerr << " Coqui STT: " << ds_git_version() << std::endl;


### PR DESCRIPTION
This PR allows model paths to include UTF-8 characters that are included in the en_US locale. 

This may not be enough for characters that are not included in this locale (sanscript, etc), but trying to use the user's locale did not work at first. It might be interesting to investigate this possibility in the future, but for now this is a quick win.