### PR TITLE
Feat/neptune

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,7 +1,7 @@
 # Please refer to the USING documentation, "Dockerfile for building from source"
 
 # Need devel version cause we need /usr/include/cudnn.h
-FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04
+FROM nvcr.io/nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04
 
 # >> START Install base software
 

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ def main():
         "webdataset==0.1.103",
         "miniaudio",
         "clearml",
+        "neptune",
     ]
 
     decoder_pypi_dep = ["coqui_stt_ctcdecoder == {}".format(version)]

--- a/training/coqui_stt_training/evaluate.py
+++ b/training/coqui_stt_training/evaluate.py
@@ -191,7 +191,7 @@ def main():
     check_ctcdecoder_version()
 
     neptune_client.start_run(
-        Config.run_api_project, Config.run_api_token, Config.run_id
+        Config.run_api_project, Config.run_api_token, Config.run_id, "test"
     )
     neptune_client.log_score("parameters/beam_width", Config.beam_width)
     neptune_client.log_score("parameters/random_seed", Config.random_seed)

--- a/training/coqui_stt_training/evaluate.py
+++ b/training/coqui_stt_training/evaluate.py
@@ -202,7 +202,7 @@ def main():
     check_ctcdecoder_version()
 
     neptune_client.start_run(
-        Config.run_api_project, Config.run_api_token, Config.run_id, "test"
+        Config.neptune_project, Config.neptune_api_token, Config.neptune_run_id, "test"
     )
     neptune_client.log_score("parameters/beam_width", Config.beam_width)
     neptune_client.log_score("parameters/random_seed", Config.random_seed)

--- a/training/coqui_stt_training/evaluate_export.py
+++ b/training/coqui_stt_training/evaluate_export.py
@@ -112,9 +112,14 @@ def main():
         wavlist.append(msg["wav"])
 
     # Print test summary
-    _ = calculate_and_print_report(
+    _, test_wer, test_cer = calculate_and_print_report(
         wav_filenames, ground_truths, predictions, losses, args.csv
     )
+
+    if neptune_run:
+        neptune_run["test_export/test_loss"].append(losses)
+        neptune_run["test_export/test_wer"].log(test_wer)
+        neptune_run["test_export/test_cer"].log(test_cer)
 
     if args.dump:
         with open(args.dump + ".txt", "w") as ftxt, open(

--- a/training/coqui_stt_training/evaluate_export.py
+++ b/training/coqui_stt_training/evaluate_export.py
@@ -116,11 +116,6 @@ def main():
         wav_filenames, ground_truths, predictions, losses, args.csv
     )
 
-    if neptune_run:
-        neptune_run["test_export/test_loss"].append(losses)
-        neptune_run["test_export/test_wer"].log(test_wer)
-        neptune_run["test_export/test_cer"].log(test_cer)
-
     if args.dump:
         with open(args.dump + ".txt", "w") as ftxt, open(
             args.dump + ".out", "w"

--- a/training/coqui_stt_training/evaluate_flashlight.py
+++ b/training/coqui_stt_training/evaluate_flashlight.py
@@ -164,7 +164,7 @@ def evaluate(test_csvs, create_model):
             bar.finish()
 
             # Print test summary
-            test_samples = calculate_and_print_report(
+            test_samples, _, _ = calculate_and_print_report(
                 wav_filenames,
                 ground_truths,
                 predictions,

--- a/training/coqui_stt_training/evaluate_from_csv.py
+++ b/training/coqui_stt_training/evaluate_from_csv.py
@@ -72,7 +72,7 @@ def evaluate_from_csv(
         losses.append(0.0)
 
     # Print test summary
-    samples = calculate_and_print_report(
+    samples, _, _ = calculate_and_print_report(
         wav_filenames, ground_truths, predictions, losses, transcriptions_csv
     )
 

--- a/training/coqui_stt_training/evaluate_wav2vec2am.py
+++ b/training/coqui_stt_training/evaluate_wav2vec2am.py
@@ -194,7 +194,7 @@ def evaluate_from_emissions(
             losses.append(0.0)
 
     # Print test summary
-    samples = calculate_and_print_report(
+    samples, _, _ = calculate_and_print_report(
         wav_filenames, ground_truths, predictions, losses, csv_file
     )
 

--- a/training/coqui_stt_training/train.py
+++ b/training/coqui_stt_training/train.py
@@ -713,7 +713,10 @@ def main():
         )
 
     neptune_client.start_run(
-        Config.run_api_project, Config.run_api_token, Config.run_id
+        Config.run_api_project,
+        Config.run_api_token,
+        Config.run_id,
+        "train",
     )
     neptune_client.log_score("parameters/beam_width", Config.beam_width)
     neptune_client.log_score("parameters/random_seed", Config.random_seed)

--- a/training/coqui_stt_training/train.py
+++ b/training/coqui_stt_training/train.py
@@ -713,9 +713,9 @@ def main():
         )
 
     neptune_client.start_run(
-        Config.run_api_project,
-        Config.run_api_token,
-        Config.run_id,
+        Config.neptune_project,
+        Config.neptune_api_token,
+        Config.neptune_run_id,
         "train",
     )
     neptune_client.log_score("parameters/beam_width", Config.beam_width)

--- a/training/coqui_stt_training/util/audio.py
+++ b/training/coqui_stt_training/util/audio.py
@@ -749,7 +749,7 @@ def read_ogg_vorbis_duration(ogg_file):
     pcm_length_samples = pyogg.vorbis.ov_pcm_total(
         ctypes.byref(vf), 0  # to extract the length of the first logical bitstream
     )
-
+    pyogg.vorbis.ov_clear(ctypes.byref(vf))
     return get_pcm_duration(pcm_length_samples, audio_format)
 
 
@@ -831,6 +831,7 @@ def read_ogg_vorbis_format(ogg_file):
     channel_count = info.contents.channels
     sample_rate = info.contents.rate
     sample_width = 2  # always 16-bit
+    pyogg.vorbis.ov_clear(ctypes.byref(vf))
     return AudioFormat(sample_rate, channel_count, sample_width)
 
 

--- a/training/coqui_stt_training/util/config.py
+++ b/training/coqui_stt_training/util/config.py
@@ -440,19 +440,19 @@ class BaseSttConfig(Coqpit):
     )
 
     # Global Constants
-    run_id: str = field(
+    neptune_run_id: str = field(
         default="",
         metadata=dict(
             help="run ID to be used for ML logging - defaults to empty (no logging)"
         ),
     )
-    run_api_token: str = field(
+    neptune_api_token: str = field(
         default="",
         metadata=dict(
             help="run api token to be used for ML logging - defaults to empty (no logging)"
         ),
     )
-    run_api_project: str = field(
+    neptune_project: str = field(
         default="",
         metadata=dict(
             help="run api project name to be used for ML logging - defaults to empty (no logging)"

--- a/training/coqui_stt_training/util/config.py
+++ b/training/coqui_stt_training/util/config.py
@@ -440,6 +440,24 @@ class BaseSttConfig(Coqpit):
     )
 
     # Global Constants
+    run_id: str = field(
+        default="",
+        metadata=dict(
+            help="run ID to be used for ML logging - defaults to empty (no logging)"
+        ),
+    )
+    run_api_token: str = field(
+        default="",
+        metadata=dict(
+            help="run api token to be used for ML logging - defaults to empty (no logging)"
+        ),
+    )
+    run_api_project: str = field(
+        default="",
+        metadata=dict(
+            help="run api project name to be used for ML logging - defaults to empty (no logging)"
+        ),
+    )
     epochs: int = field(
         default=75,
         metadata=dict(

--- a/training/coqui_stt_training/util/evaluate_tools.py
+++ b/training/coqui_stt_training/util/evaluate_tools.py
@@ -105,7 +105,7 @@ def calculate_and_print_report(
     # Print the report
     print_report(samples, losses, samples_wer, samples_cer, dataset_name, report_count)
 
-    return samples
+    return samples, samples_wer, samples_cer
 
 
 def print_report(samples, losses, wer, cer, dataset_name, report_count=5):

--- a/training/coqui_stt_training/util/neptune_config.py
+++ b/training/coqui_stt_training/util/neptune_config.py
@@ -1,0 +1,102 @@
+import neptune
+
+from .config import (
+    log_info,
+)
+
+
+def neptune_run_required(method):
+    """
+    Decorator to check if self.nep_run exists before calling the method.
+    """
+
+    def wrapper(self, *args, **kwargs):
+        if self.nep_run:
+            return method(self, *args, **kwargs)
+
+    return wrapper
+
+
+class NeptuneClient:
+    def __init__(self):
+        self.nep_run = None
+        self.run_id = ""
+        self.project = ""
+        self.api_token = ""
+
+    def start_run(self, neptune_project, neptune_api_token, run_id):
+        if neptune_project and neptune_api_token:
+            run_id = run_id if run_id else None
+            self.nep_run = neptune.init_run(
+                project=neptune_project,
+                api_token=neptune_api_token,
+                with_id=run_id,
+            )
+            self.run_id = run_id
+            self.project = neptune_project
+            self.api_token = neptune_api_token
+            log_info("Neptune run started.")
+            log_info(f"Neptune project {self.project}")
+            log_info(f"Neptune API token {self.api_token}")
+            log_info(f"Neptune run ID {self.nep_run['sys/id'].fetch()}")
+        else:
+            log_info("Neptune run not started.")
+
+    @neptune_run_required
+    def track_artifact(self, name, path):
+        """
+        Track an artifact (file) within the current Neptune run.
+        Useful if you want to track a file that is not uploaded to Neptune,
+        for example, large files.
+
+        Args:
+            name (str): Where to store the artifact.
+            path (str): The path to the artifact file.
+
+        """
+        self.nep_run[name].track_files(path)
+
+    @neptune_run_required
+    def upload_artifact(self, name, path):
+        """
+        Upload an artifact (file) to the current Neptune run.
+
+        Args:
+            name (str): Where to store the artifact.
+            path (str): The path to the artifact file.
+
+        """
+        self.nep_run[name].upload(path)
+
+    @neptune_run_required
+    def log_metric(self, name, value):
+        """
+        Log a metric value to the current Neptune run.
+        Metric values are usually values tracked over time.
+
+        Args:
+            name (str): The name of the metric.
+            value: The value of the metric.
+
+        """
+        self.nep_run[name].append(value)
+
+    @neptune_run_required
+    def log_score(self, name, value):
+        """
+        Log a score value to the current Neptune run.
+        A "score" value can be anything that is not a metric.
+
+        Args:
+            name (str): The name of the score.
+            value: The value of the score.
+
+        """
+        self.nep_run[name] = value
+
+    @neptune_run_required
+    def stop_run(self):
+        self.nep_run.stop()
+
+
+neptune_client = NeptuneClient()

--- a/training/coqui_stt_training/util/neptune_config.py
+++ b/training/coqui_stt_training/util/neptune_config.py
@@ -24,6 +24,7 @@ class NeptuneClient:
         self.run_id = ""
         self.project = ""
         self.api_token = ""
+        self.enabled = False
 
     def start_run(self, neptune_project, neptune_api_token, run_id, monitoring_name):
         if neptune_project and neptune_api_token:
@@ -38,6 +39,7 @@ class NeptuneClient:
             self.run_id = run_id
             self.project = neptune_project
             self.api_token = neptune_api_token
+            self.enabled = True
             log_info("Neptune run started.")
             log_info(f"Neptune project {self.project}")
             log_info(f"Neptune API token {self.api_token}")
@@ -105,6 +107,7 @@ class NeptuneClient:
     @neptune_run_required
     def stop_run(self):
         self.nep_run.stop()
+        self.enabled = False
 
 
 neptune_client = NeptuneClient()

--- a/training/coqui_stt_training/util/neptune_config.py
+++ b/training/coqui_stt_training/util/neptune_config.py
@@ -25,13 +25,15 @@ class NeptuneClient:
         self.project = ""
         self.api_token = ""
 
-    def start_run(self, neptune_project, neptune_api_token, run_id):
+    def start_run(self, neptune_project, neptune_api_token, run_id, monitoring_name):
         if neptune_project and neptune_api_token:
             run_id = run_id if run_id else None
+            monitoring_name = f"monitoring/{monitoring_name}"
             self.nep_run = neptune.init_run(
                 project=neptune_project,
                 api_token=neptune_api_token,
                 with_id=run_id,
+                monitoring_namespace=monitoring_name,
             )
             self.run_id = run_id
             self.project = neptune_project

--- a/training/coqui_stt_training/util/neptune_config.py
+++ b/training/coqui_stt_training/util/neptune_config.py
@@ -1,4 +1,5 @@
 import neptune
+import numpy as np
 
 from .config import (
     log_info,
@@ -79,7 +80,12 @@ class NeptuneClient:
             value: The value of the metric.
 
         """
-        self.nep_run[name].append(value)
+        if isinstance(value, (np.ndarray, list)):
+            if isinstance(value, np.ndarray):
+                value = value.tolist()
+            self.nep_run[name].extend(value)
+        else:
+            self.nep_run[name].append(value)
 
     @neptune_run_required
     def log_score(self, name, value):


### PR DESCRIPTION
This PR to `dev` refers to the implementation of [Neptune](https://neptune.ai/) support for our coqui-stt fork. It includes, among others, the recording of metrics such as training/validation/test loss, test CER/WER, hardware usage, etc.

The implementation of Neptune is meant to be as optional as possible, meaning that it will only be used if `--run_api_token` and `--run_api_project` (and optionally `--run_id`) are passed as arguments.

Additionally, the memory-leak for Vorbis OGG files was fixed.